### PR TITLE
Add SQL schema and PHP starter scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # MI
+
 Mohamed Ibrahim Spare Parts Project
+
+## Setup
+
+1. Create a MySQL database on your hosting account and note the credentials.
+2. Update `public/config.php` with your database name, username and password.
+3. Upload the contents of the `public` directory to your PHP hosting space.
+4. Run `init_db.php` once in your browser to create the required tables.
+5. Access `index.php` to manage products.
+
+The SQL schema is stored in `sql/schema.sql` if you wish to create the tables manually.

--- a/public/config.php
+++ b/public/config.php
@@ -1,0 +1,21 @@
+<?php
+// Database configuration
+$host = 'localhost';
+$db   = 'your_database_name';
+$user = 'your_db_user';
+$pass = 'your_db_password';
+$charset = 'utf8mb4';
+
+$dsn = "mysql:host=$host;dbname=$db;charset=$charset";
+$options = [
+    PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    PDO::ATTR_EMULATE_PREPARES   => false,
+];
+
+try {
+    $pdo = new PDO($dsn, $user, $pass, $options);
+} catch (PDOException $e) {
+    throw new PDOException($e->getMessage(), (int)$e->getCode());
+}
+?>

--- a/public/index.php
+++ b/public/index.php
@@ -1,0 +1,17 @@
+<?php
+require_once 'config.php';
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Inventory System</title>
+</head>
+<body>
+    <h1>Inventory Management</h1>
+    <ul>
+        <li><a href="products.php">Products</a></li>
+        <li><a href="init_db.php">Initialize Database</a></li>
+    </ul>
+</body>
+</html>

--- a/public/init_db.php
+++ b/public/init_db.php
@@ -1,0 +1,12 @@
+<?php
+require_once 'config.php';
+
+$schema = file_get_contents(__DIR__ . '/../sql/schema.sql');
+
+try {
+    $pdo->exec($schema);
+    echo "Database initialized successfully.";
+} catch (PDOException $e) {
+    echo "Database initialization failed: " . $e->getMessage();
+}
+?>

--- a/public/products.php
+++ b/public/products.php
@@ -1,0 +1,87 @@
+<?php
+require_once 'config.php';
+
+// Handle form submission to add product
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $stmt = $pdo->prepare('INSERT INTO products (name_en, name_ar, category_id, supplier_id, cost, price, stock, description) VALUES (?,?,?,?,?,?,?,?)');
+    $stmt->execute([
+        $_POST['name_en'],
+        $_POST['name_ar'],
+        $_POST['category_id'] ?: null,
+        $_POST['supplier_id'] ?: null,
+        $_POST['cost'],
+        $_POST['price'],
+        $_POST['stock'],
+        $_POST['description'],
+    ]);
+}
+
+$products = $pdo->query('SELECT p.*, s.name AS supplier_name, c.name_en AS category_name FROM products p LEFT JOIN suppliers s ON p.supplier_id = s.id LEFT JOIN categories c ON p.category_id = c.id ORDER BY p.id DESC')->fetchAll();
+$suppliers = $pdo->query('SELECT id, name FROM suppliers')->fetchAll();
+$categories = $pdo->query('SELECT id, name_en FROM categories')->fetchAll();
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Products</title>
+    <style>
+        table { border-collapse: collapse; width: 100%; }
+        th, td { padding: 8px; border: 1px solid #ccc; }
+        form { margin-bottom: 20px; }
+    </style>
+</head>
+<body>
+    <h1>Products</h1>
+    <form method="post">
+        <input type="text" name="name_en" placeholder="Name (EN)" required>
+        <input type="text" name="name_ar" placeholder="Name (AR)" required>
+        <select name="category_id">
+            <option value="">Select Category</option>
+            <?php foreach ($categories as $cat): ?>
+                <option value="<?= $cat['id'] ?>"><?= htmlspecialchars($cat['name_en']) ?></option>
+            <?php endforeach; ?>
+        </select>
+        <select name="supplier_id">
+            <option value="">Select Supplier</option>
+            <?php foreach ($suppliers as $sup): ?>
+                <option value="<?= $sup['id'] ?>"><?= htmlspecialchars($sup['name']) ?></option>
+            <?php endforeach; ?>
+        </select>
+        <input type="number" step="0.01" name="cost" placeholder="Cost" required>
+        <input type="number" step="0.01" name="price" placeholder="Price" required>
+        <input type="number" name="stock" placeholder="Stock" value="0">
+        <input type="text" name="description" placeholder="Description">
+        <button type="submit">Add Product</button>
+    </form>
+
+    <table>
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Name (EN)</th>
+                <th>Name (AR)</th>
+                <th>Category</th>
+                <th>Supplier</th>
+                <th>Cost</th>
+                <th>Price</th>
+                <th>Stock</th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ($products as $p): ?>
+                <tr>
+                    <td><?= $p['id'] ?></td>
+                    <td><?= htmlspecialchars($p['name_en']) ?></td>
+                    <td><?= htmlspecialchars($p['name_ar']) ?></td>
+                    <td><?= htmlspecialchars($p['category_name']) ?></td>
+                    <td><?= htmlspecialchars($p['supplier_name']) ?></td>
+                    <td><?= $p['cost'] ?></td>
+                    <td><?= $p['price'] ?></td>
+                    <td><?= $p['stock'] ?></td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+</body>
+</html>

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -1,0 +1,109 @@
+CREATE TABLE brands (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name_en VARCHAR(100),
+    name_ar VARCHAR(100)
+);
+
+CREATE TABLE models (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    brand_id INT,
+    name VARCHAR(100),
+    FOREIGN KEY (brand_id) REFERENCES brands(id) ON DELETE CASCADE
+);
+
+CREATE TABLE categories (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    parent_id INT DEFAULT NULL,
+    name_en VARCHAR(100),
+    name_ar VARCHAR(100),
+    FOREIGN KEY (parent_id) REFERENCES categories(id) ON DELETE SET NULL
+);
+
+CREATE TABLE suppliers (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(100),
+    email VARCHAR(100),
+    phone VARCHAR(20),
+    mobile VARCHAR(20),
+    address TEXT,
+    notes TEXT
+);
+
+CREATE TABLE products (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name_en VARCHAR(150),
+    name_ar VARCHAR(150),
+    category_id INT,
+    supplier_id INT,
+    cost DECIMAL(10,2),
+    price DECIMAL(10,2),
+    stock INT DEFAULT 0,
+    description TEXT,
+    FOREIGN KEY (category_id) REFERENCES categories(id) ON DELETE SET NULL,
+    FOREIGN KEY (supplier_id) REFERENCES suppliers(id) ON DELETE SET NULL
+);
+
+CREATE TABLE product_model_map (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    product_id INT,
+    brand_id INT,
+    model_id INT DEFAULT NULL,
+    FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE CASCADE,
+    FOREIGN KEY (brand_id) REFERENCES brands(id) ON DELETE CASCADE,
+    FOREIGN KEY (model_id) REFERENCES models(id) ON DELETE CASCADE
+);
+
+CREATE TABLE customers (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    code VARCHAR(20) UNIQUE,
+    name VARCHAR(100),
+    email VARCHAR(100),
+    phone VARCHAR(20),
+    mobile VARCHAR(20),
+    address TEXT
+);
+
+CREATE TABLE purchases (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    supplier_id INT,
+    date DATE,
+    notes TEXT,
+    FOREIGN KEY (supplier_id) REFERENCES suppliers(id)
+);
+
+CREATE TABLE purchase_items (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    purchase_id INT,
+    product_id INT,
+    quantity INT,
+    cost DECIMAL(10,2),
+    FOREIGN KEY (purchase_id) REFERENCES purchases(id),
+    FOREIGN KEY (product_id) REFERENCES products(id)
+);
+
+CREATE TABLE sales (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    customer_id INT,
+    date DATE,
+    type ENUM('quote', 'order', 'invoice'),
+    status ENUM('draft', 'confirmed', 'paid', 'cancelled'),
+    notes TEXT,
+    FOREIGN KEY (customer_id) REFERENCES customers(id)
+);
+
+CREATE TABLE sales_items (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    sale_id INT,
+    product_id INT,
+    quantity INT,
+    price DECIMAL(10,2),
+    FOREIGN KEY (sale_id) REFERENCES sales(id),
+    FOREIGN KEY (product_id) REFERENCES products(id)
+);
+
+CREATE TABLE translations (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    key_name VARCHAR(100) UNIQUE,
+    en_value TEXT,
+    ar_value TEXT
+);


### PR DESCRIPTION
## Summary
- create MySQL schema for brands, models, categories, suppliers, products and more
- add database connection config and initialization script
- add simple product management page
- document setup steps in README

## Testing
- `php -l public/config.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686cd4a6247c8328829f61f3d679e84b